### PR TITLE
Change usage of env to core.getInput & detection of push to main|master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ typings/
 
 # IDE
 .idea
+
+# Mac OS
+.DS_Store

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,10 @@ inputs:
     description: "The directory to look for migrations"
   space_id:
     description: "The id of the contentful space"
+    required: true
   management_api_key:
     description: "The management-api key for contentful"
+    required: true
 
 outputs:
   environment_url:

--- a/dist/index.js
+++ b/dist/index.js
@@ -98659,7 +98659,8 @@ var to_semver_default = /*#__PURE__*/__webpack_require__.n(to_semver);
 // CONCATENATED MODULE: ./src/constants.ts
 var constants_a;
 
-var GITHUB_WORKSPACE = (constants_a = process.env, constants_a.GITHUB_WORKSPACE), LOG_LEVEL = constants_a.LOG_LEVEL, SPACE_ID = constants_a.INPUT_SPACE_ID, MANAGEMENT_API_KEY = constants_a.INPUT_MANAGEMENT_API_KEY, INPUT_MIGRATIONS_DIR = constants_a.INPUT_MIGRATIONS_DIR, INPUT_DELETE_FEATURE = constants_a.INPUT_DELETE_FEATURE, INPUT_SET_ALIAS = constants_a.INPUT_SET_ALIAS, INPUT_FEATURE_PATTERN = constants_a.INPUT_FEATURE_PATTERN, INPUT_MASTER_PATTERN = constants_a.INPUT_MASTER_PATTERN, INPUT_VERSION_CONTENT_TYPE = constants_a.INPUT_VERSION_CONTENT_TYPE, INPUT_VERSION_FIELD = constants_a.INPUT_VERSION_FIELD;
+
+var GITHUB_WORKSPACE = (constants_a = process.env, constants_a.GITHUB_WORKSPACE), LOG_LEVEL = constants_a.LOG_LEVEL;
 var booleanOr = function (str, fallback) {
     switch (str) {
         case "true":
@@ -98670,6 +98671,12 @@ var booleanOr = function (str, fallback) {
             return fallback;
     }
 };
+var getInputOr = function (coreInput, fallback) {
+    if (coreInput) {
+        return Object(core.getInput)(coreInput);
+    }
+    return fallback;
+};
 var DEFAULT_MIGRATIONS_DIR = "migrations";
 var DEFAULT_MASTER_PATTERN = "master-[YYYY]-[MM]-[DD]-[mm][ss]";
 var DEFAULT_FEATURE_PATTERN = "GH-[branch]";
@@ -98677,13 +98684,15 @@ var DEFAULT_VERSION_CONTENT_TYPE = "versionTracking";
 var DEFAULT_VERSION_FIELD = "version";
 var DEFAULT_DELETE_FEATURE = false;
 var DEFAULT_SET_ALIAS = false;
-var VERSION_CONTENT_TYPE = INPUT_VERSION_CONTENT_TYPE || DEFAULT_VERSION_CONTENT_TYPE;
-var FEATURE_PATTERN = INPUT_FEATURE_PATTERN || DEFAULT_FEATURE_PATTERN;
-var MASTER_PATTERN = INPUT_MASTER_PATTERN || DEFAULT_MASTER_PATTERN;
-var VERSION_FIELD = INPUT_VERSION_FIELD || DEFAULT_VERSION_FIELD;
-var DELETE_FEATURE = booleanOr(INPUT_DELETE_FEATURE, DEFAULT_DELETE_FEATURE);
-var SET_ALIAS = booleanOr(INPUT_SET_ALIAS, DEFAULT_SET_ALIAS);
-var MIGRATIONS_DIR = external_path_default().join(GITHUB_WORKSPACE, INPUT_MIGRATIONS_DIR || DEFAULT_MIGRATIONS_DIR);
+var SPACE_ID = Object(core.getInput)('space_id', { required: true });
+var MANAGEMENT_API_KEY = Object(core.getInput)('management_api_key', { required: true });
+var VERSION_CONTENT_TYPE = getInputOr('version_content_type', DEFAULT_VERSION_CONTENT_TYPE);
+var FEATURE_PATTERN = getInputOr('feature_pattern', DEFAULT_FEATURE_PATTERN);
+var MASTER_PATTERN = getInputOr('master_pattern', DEFAULT_MASTER_PATTERN);
+var VERSION_FIELD = getInputOr('version_field', DEFAULT_VERSION_FIELD);
+var DELETE_FEATURE = booleanOr(Object(core.getInput)('delete_feature'), DEFAULT_DELETE_FEATURE);
+var SET_ALIAS = booleanOr(Object(core.getInput)('set_alias'), DEFAULT_SET_ALIAS);
+var MIGRATIONS_DIR = external_path_default().join(GITHUB_WORKSPACE, getInputOr('migrations_dir', DEFAULT_MIGRATIONS_DIR));
 var CONTENTFUL_ALIAS = "master";
 var DELAY = 3000;
 var MAX_NUMBER_OF_TRIES = 10;
@@ -99109,25 +99118,23 @@ var runAction = function (space) { return Object(tslib.__awaiter)(void 0, void 0
     return Object(tslib.__generator)(this, function (_a) {
         switch (_a.label) {
             case 0:
+                _a.trys.push([0, 3, , 4]);
                 client = Object(contentful_management_node.createClient)({
                     accessToken: MANAGEMENT_API_KEY,
                 });
                 return [4 /*yield*/, client.getSpace(SPACE_ID)];
             case 1:
                 space = _a.sent();
-                _a.label = 2;
-            case 2:
-                _a.trys.push([2, 4, , 5]);
                 return [4 /*yield*/, runAction(space)];
-            case 3:
+            case 2:
                 _a.sent();
-                return [3 /*break*/, 5];
-            case 4:
+                return [3 /*break*/, 4];
+            case 3:
                 error_1 = _a.sent();
                 Logger.error(error_1);
                 Object(core.setFailed)(error_1.message);
-                return [3 /*break*/, 5];
-            case 5: return [2 /*return*/];
+                return [3 /*break*/, 4];
+            case 4: return [2 /*return*/];
         }
     });
 }); })();

--- a/dist/index.js
+++ b/dist/index.js
@@ -98829,7 +98829,7 @@ var getNameFromPattern = function (pattern, _a) {
  * Get the branchNames based on the eventName
  */
 var getBranchNames = function () {
-    var _a = github.context, eventName = _a.eventName, payload = _a.payload;
+    var _a = github.context, eventName = _a.eventName, payload = _a.payload, ref = _a.ref;
     var defaultBranch = payload.repository.default_branch;
     // Check the eventName
     switch (eventName) {
@@ -98844,7 +98844,7 @@ var getBranchNames = function () {
         default:
             return {
                 headRef: null,
-                baseRef: payload.ref.replace(/^refs\/heads\//, ""),
+                baseRef: ref.replace(/^refs\/heads\//, ""),
                 defaultBranch: defaultBranch,
             };
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -98722,16 +98722,16 @@ var Logger = {
         console.log(source_default().white(message));
     },
     success: function (message) {
-        console.log("✅", source_default().green(message));
+        console.log('✅', source_default().green(message));
     },
     error: function (message) {
-        console.log("💩", source_default().red(message));
+        console.log('💩', source_default().red(message));
     },
     warn: function (message) {
-        console.log("⚠️", source_default().yellow(message));
+        console.log('⚠️', source_default().yellow(message));
     },
     verbose: function (message) {
-        if (LOG_LEVEL === "verbose") {
+        if (LOG_LEVEL === 'verbose') {
             console.log(source_default().white(message));
         }
     },
@@ -98750,25 +98750,19 @@ var delay = function (time) {
  * filenameToVersion("1.js") // "1"
  * filenameToVersion("1.0.1.js") // "1.0.1"
  */
-var filenameToVersion = function (file) {
-    return file.replace(/\.js$/, "").replace(/_/g, ".");
-};
+var filenameToVersion = function (file) { return file.replace(/\.js$/, '').replace(/_/g, '.'); };
 /**
  * Convert versions to filenames
  * @example
  * versionToFilename("1") // "1.js"
  * versionToFilename("1.0.1") // "1.0.1.js"
  */
-var versionToFilename = function (version) {
-    return version.replace(/\\./g, "_") + ".js";
-};
+var versionToFilename = function (version) { return version.replace(/\\./g, '_') + ".js"; };
 /**
  * Convert a branchName to a valid environmentName
  * @param branchName
  */
-var branchNameToEnvironmentName = function (branchName) {
-    return branchName.replace(/[\/_.]/g, "-");
-};
+var branchNameToEnvironmentName = function (branchName) { return branchName.replace(/[\/_.]/g, '-'); };
 var Matcher;
 (function (Matcher) {
     Matcher["YY"] = "YY";
@@ -98781,24 +98775,14 @@ var Matcher;
     Matcher["branch"] = "branch";
 })(Matcher || (Matcher = {}));
 var matchers = (utils_a = {},
-    utils_a[Matcher.ss] = function (date) {
-        return ("" + date.getUTCSeconds()).padStart(2, "0");
-    },
-    utils_a[Matcher.hh] = function (date) {
-        return ("" + date.getUTCHours()).padStart(2, "0");
-    },
-    utils_a[Matcher.mm] = function (date) {
-        return ("" + date.getUTCMinutes()).padStart(2, "0");
-    },
+    utils_a[Matcher.ss] = function (date) { return ("" + date.getUTCSeconds()).padStart(2, '0'); },
+    utils_a[Matcher.hh] = function (date) { return ("" + date.getUTCHours()).padStart(2, '0'); },
+    utils_a[Matcher.mm] = function (date) { return ("" + date.getUTCMinutes()).padStart(2, '0'); },
     utils_a[Matcher.YYYY] = function (date) { return "" + date.getUTCFullYear(); },
     utils_a[Matcher.YY] = function (date) { return ("" + date.getUTCFullYear()).substr(2, 2); },
-    utils_a[Matcher.MM] = function (date) {
-        return ("" + (date.getUTCMonth() + 1)).padStart(2, "0");
-    },
-    utils_a[Matcher.DD] = function (date) { return ("" + date.getDate()).padStart(2, "0"); },
-    utils_a[Matcher.branch] = function (branchName) {
-        return branchNameToEnvironmentName(branchName);
-    },
+    utils_a[Matcher.MM] = function (date) { return ("" + (date.getUTCMonth() + 1)).padStart(2, '0'); },
+    utils_a[Matcher.DD] = function (date) { return ("" + date.getDate()).padStart(2, '0'); },
+    utils_a[Matcher.branch] = function (branchName) { return branchNameToEnvironmentName(branchName); },
     utils_a);
 /**
  *
@@ -98845,7 +98829,7 @@ var getBranchNames = function () {
         default:
             return {
                 headRef: null,
-                baseRef: payload.ref.replace(/^refs\/heads\//, ""),
+                baseRef: payload.ref.replace(/^refs\/heads\//, ''),
                 defaultBranch: defaultBranch,
             };
     }
@@ -98859,23 +98843,22 @@ var getBranchNames = function () {
 var getEnvironment = function (space, branchNames) { return Object(tslib.__awaiter)(void 0, void 0, void 0, function () {
     var environmentNames, environmentType, environmentId, environment, e_1;
     var _a, _b;
-    var _c;
-    return Object(tslib.__generator)(this, function (_d) {
-        switch (_d.label) {
+    var _c, _d;
+    return Object(tslib.__generator)(this, function (_e) {
+        switch (_e.label) {
             case 0:
                 environmentNames = {
                     base: branchNameToEnvironmentName(branchNames.baseRef),
-                    head: branchNames.headRef
-                        ? branchNameToEnvironmentName(branchNames.headRef)
-                        : null,
+                    head: branchNames.headRef ? branchNameToEnvironmentName(branchNames.headRef) : null,
                 };
                 // If the Pull Request is merged and the base is the repository default_name (master|main, ...)
                 // Then create an environment name for the given master_pattern
                 // Else create an environment name for the given feature_pattern
                 Logger.verbose("MASTER_PATTERN: " + MASTER_PATTERN + " | FEATURE_PATTERN: " + FEATURE_PATTERN);
-                environmentType = branchNames.baseRef === branchNames.defaultBranch && ((_c = github.context.payload.pull_request) === null || _c === void 0 ? void 0 : _c.merged)
-                    ? CONTENTFUL_ALIAS
-                    : "feature";
+                environmentType = branchNames.baseRef === branchNames.defaultBranch ? CONTENTFUL_ALIAS : 'feature';
+                if ((_d = (_c = github.context.payload) === null || _c === void 0 ? void 0 : _c.pull_request) === null || _d === void 0 ? void 0 : _d.merged) {
+                    environmentType = 'feature';
+                }
                 Logger.verbose("Environment type: " + environmentType);
                 environmentId = environmentType === CONTENTFUL_ALIAS
                     ? getNameFromPattern(MASTER_PATTERN)
@@ -98892,24 +98875,24 @@ var getEnvironment = function (space, branchNames) { return Object(tslib.__await
                 return [4 /*yield*/, space.createEnvironmentWithId(environmentId, {
                         name: environmentId,
                     })];
-            case 1: return [2 /*return*/, (_a.environment = _d.sent(),
+            case 1: return [2 /*return*/, (_a.environment = _e.sent(),
                     _a)];
             case 2:
                 // Else we need to check for an existing environment and flush it
                 Logger.log("Checking for existing versions of environment: \"" + environmentId + "\"");
-                _d.label = 3;
+                _e.label = 3;
             case 3:
-                _d.trys.push([3, 6, , 7]);
+                _e.trys.push([3, 6, , 7]);
                 return [4 /*yield*/, space.getEnvironment(environmentId)];
             case 4:
-                environment = _d.sent();
+                environment = _e.sent();
                 return [4 /*yield*/, (environment === null || environment === void 0 ? void 0 : environment.delete())];
             case 5:
-                _d.sent();
+                _e.sent();
                 Logger.success("Environment deleted: \"" + environmentId + "\"");
                 return [3 /*break*/, 7];
             case 6:
-                e_1 = _d.sent();
+                e_1 = _e.sent();
                 Logger.log("Environment not found: \"" + environmentId + "\"");
                 return [3 /*break*/, 7];
             case 7:
@@ -98922,7 +98905,7 @@ var getEnvironment = function (space, branchNames) { return Object(tslib.__await
                 return [4 /*yield*/, space.createEnvironmentWithId(environmentId, {
                         name: environmentId,
                     })];
-            case 8: return [2 /*return*/, (_b.environment = _d.sent(),
+            case 8: return [2 /*return*/, (_b.environment = _e.sent(),
                     _b)];
         }
     });

--- a/dist/index.js
+++ b/dist/index.js
@@ -98672,8 +98672,9 @@ var booleanOr = function (str, fallback) {
     }
 };
 var getInputOr = function (coreInput, fallback) {
-    if (coreInput) {
-        return Object(core.getInput)(coreInput);
+    var input = Object(core.getInput)(coreInput);
+    if (input) {
+        return input;
     }
     return fallback;
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -98831,6 +98831,7 @@ var getNameFromPattern = function (pattern, _a) {
 var getBranchNames = function () {
     var _a = github.context, eventName = _a.eventName, payload = _a.payload, ref = _a.ref;
     var defaultBranch = payload.repository.default_branch;
+    Logger.verbose("Getting branch names for " + eventName);
     // Check the eventName
     switch (eventName) {
         // If pullRequest we need to get the head and base
@@ -98842,9 +98843,10 @@ var getBranchNames = function () {
             };
         // If not pullRequest we need work on the baseRef therefore head is null
         default:
+            Logger.verbose("Return branch names for " + eventName + " with baseRef " + payload.ref);
             return {
                 headRef: null,
-                baseRef: ref.replace(/^refs\/heads\//, ""),
+                baseRef: payload.ref.replace(/^refs\/heads\//, ""),
                 defaultBranch: defaultBranch,
             };
     }

--- a/dist/index.js
+++ b/dist/index.js
@@ -98831,7 +98831,7 @@ var getNameFromPattern = function (pattern, _a) {
 var getBranchNames = function () {
     var _a = github.context, eventName = _a.eventName, payload = _a.payload, ref = _a.ref;
     var defaultBranch = payload.repository.default_branch;
-    Logger.verbose("Getting branch names for " + eventName);
+    Logger.verbose("Getting branch names for \"" + eventName + "\"");
     // Check the eventName
     switch (eventName) {
         // If pullRequest we need to get the head and base
@@ -98843,7 +98843,6 @@ var getBranchNames = function () {
             };
         // If not pullRequest we need work on the baseRef therefore head is null
         default:
-            Logger.verbose("Return branch names for " + eventName + " with baseRef " + payload.ref);
             return {
                 headRef: null,
                 baseRef: payload.ref.replace(/^refs\/heads\//, ""),
@@ -98877,6 +98876,7 @@ var getEnvironment = function (space, branchNames) { return Object(tslib.__await
                 environmentType = branchNames.baseRef === branchNames.defaultBranch && ((_c = github.context.payload.pull_request) === null || _c === void 0 ? void 0 : _c.merged)
                     ? CONTENTFUL_ALIAS
                     : "feature";
+                Logger.verbose("Environment type: " + environmentType);
                 environmentId = environmentType === CONTENTFUL_ALIAS
                     ? getNameFromPattern(MASTER_PATTERN)
                     : getNameFromPattern(FEATURE_PATTERN, {
@@ -98951,9 +98951,11 @@ var runAction = function (space) { return Object(tslib.__awaiter)(void 0, void 0
         switch (_d.label) {
             case 0:
                 branchNames = getBranchNames();
+                Logger.verbose("Branch names for getting environment " + JSON.stringify(branchNames));
                 return [4 /*yield*/, getEnvironment(space, branchNames)];
             case 1:
                 _a = _d.sent(), environmentId = _a.environmentId, environment = _a.environment, environmentType = _a.environmentType;
+                Logger.verbose("environment id: " + environmentId + " | environment: " + JSON.stringify(environment) + " |\u00A0environment type: " + environmentType);
                 count = 0;
                 Logger.log("Waiting for environment processing...");
                 _d.label = 2;

--- a/dist/src/constants.d.ts
+++ b/dist/src/constants.d.ts
@@ -1,4 +1,4 @@
-export declare const GITHUB_WORKSPACE: string, LOG_LEVEL: string, SPACE_ID: string, MANAGEMENT_API_KEY: string, INPUT_MIGRATIONS_DIR: string, INPUT_DELETE_FEATURE: string, INPUT_SET_ALIAS: string, INPUT_FEATURE_PATTERN: string, INPUT_MASTER_PATTERN: string, INPUT_VERSION_CONTENT_TYPE: string, INPUT_VERSION_FIELD: string;
+export declare const GITHUB_WORKSPACE: string, LOG_LEVEL: string;
 export declare const DEFAULT_MIGRATIONS_DIR = "migrations";
 export declare const DEFAULT_MASTER_PATTERN = "master-[YYYY]-[MM]-[DD]-[mm][ss]";
 export declare const DEFAULT_FEATURE_PATTERN = "GH-[branch]";
@@ -6,6 +6,8 @@ export declare const DEFAULT_VERSION_CONTENT_TYPE = "versionTracking";
 export declare const DEFAULT_VERSION_FIELD = "version";
 export declare const DEFAULT_DELETE_FEATURE = false;
 export declare const DEFAULT_SET_ALIAS = false;
+export declare const SPACE_ID: string;
+export declare const MANAGEMENT_API_KEY: string;
 export declare const VERSION_CONTENT_TYPE: string;
 export declare const FEATURE_PATTERN: string;
 export declare const MASTER_PATTERN: string;

--- a/dist/src/types.d.ts
+++ b/dist/src/types.d.ts
@@ -11,7 +11,7 @@ export interface EnvironmentNames {
     base: string;
     head: string | null;
 }
-declare type EnvironmentType = "master" | "feature";
+export declare type EnvironmentType = "master" | "feature";
 export interface EnvironmentProps {
     environmentType: EnvironmentType;
     environmentNames: EnvironmentNames;
@@ -21,4 +21,3 @@ export interface EnvironmentProps {
 export interface NameFromPatternArgs {
     branchName?: string;
 }
-export {};

--- a/dist/src/utils.d.ts
+++ b/dist/src/utils.d.ts
@@ -1,5 +1,5 @@
-import { Space } from "contentful-management/dist/typings/entities/space";
-import { BranchNames, EnvironmentProps, NameFromPatternArgs } from "./types";
+import { Space } from 'contentful-management/dist/typings/entities/space';
+import { BranchNames, EnvironmentProps, NameFromPatternArgs } from './types';
 export declare const Logger: {
     log(message: any): void;
     success(message: any): void;

--- a/src/action.ts
+++ b/src/action.ts
@@ -36,10 +36,13 @@ export const readdirAsync = promisify(readdir);
  */
 export const runAction = async (space): Promise<void> => {
   const branchNames = getBranchNames();
+  Logger.verbose(`Branch names for getting environment ${JSON.stringify(branchNames)}`);
   const { environmentId, environment, environmentType } = await getEnvironment(
     space,
     branchNames
   );
+
+  Logger.verbose(`environment id: ${environmentId} | environment: ${JSON.stringify(environment)} | environment type: ${environmentType}`);
 
   // Counter to limit retries
   let count = 0;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,17 +1,9 @@
 import path from "path";
+import * as core from '@actions/core';
 
 export const {
   GITHUB_WORKSPACE,
   LOG_LEVEL,
-  INPUT_SPACE_ID: SPACE_ID,
-  INPUT_MANAGEMENT_API_KEY: MANAGEMENT_API_KEY,
-  INPUT_MIGRATIONS_DIR,
-  INPUT_DELETE_FEATURE,
-  INPUT_SET_ALIAS,
-  INPUT_FEATURE_PATTERN,
-  INPUT_MASTER_PATTERN,
-  INPUT_VERSION_CONTENT_TYPE,
-  INPUT_VERSION_FIELD,
 } = process.env;
 
 const booleanOr = (str: string, fallback: boolean): boolean => {
@@ -25,6 +17,13 @@ const booleanOr = (str: string, fallback: boolean): boolean => {
   }
 };
 
+const getInputOr = (coreInput: string, fallback: string): string => {
+  if ( coreInput ) {
+    return core.getInput(coreInput);
+  }
+  return fallback;
+}
+
 export const DEFAULT_MIGRATIONS_DIR = "migrations";
 export const DEFAULT_MASTER_PATTERN = "master-[YYYY]-[MM]-[DD]-[mm][ss]";
 export const DEFAULT_FEATURE_PATTERN = "GH-[branch]";
@@ -33,20 +32,13 @@ export const DEFAULT_VERSION_FIELD = "version";
 export const DEFAULT_DELETE_FEATURE = false;
 export const DEFAULT_SET_ALIAS = false;
 
-export const VERSION_CONTENT_TYPE =
-  INPUT_VERSION_CONTENT_TYPE || DEFAULT_VERSION_CONTENT_TYPE;
-export const FEATURE_PATTERN = INPUT_FEATURE_PATTERN || DEFAULT_FEATURE_PATTERN;
-export const MASTER_PATTERN = INPUT_MASTER_PATTERN || DEFAULT_MASTER_PATTERN;
-export const VERSION_FIELD = INPUT_VERSION_FIELD || DEFAULT_VERSION_FIELD;
-export const DELETE_FEATURE = booleanOr(
-  INPUT_DELETE_FEATURE,
-  DEFAULT_DELETE_FEATURE
-);
-export const SET_ALIAS = booleanOr(INPUT_SET_ALIAS, DEFAULT_SET_ALIAS);
-export const MIGRATIONS_DIR = path.join(
-  GITHUB_WORKSPACE,
-  INPUT_MIGRATIONS_DIR || DEFAULT_MIGRATIONS_DIR
-);
+export const VERSION_CONTENT_TYPE = getInputOr('version_content_type', DEFAULT_VERSION_CONTENT_TYPE);
+export const FEATURE_PATTERN = getInputOr('feature_pattern', DEFAULT_FEATURE_PATTERN);
+export const MASTER_PATTERN = getInputOr('master_pattern', DEFAULT_MASTER_PATTERN);
+export const VERSION_FIELD = getInputOr('version_field', DEFAULT_VERSION_FIELD);
+export const DELETE_FEATURE = booleanOr(core.getInput('delete_feature'), DEFAULT_DELETE_FEATURE);
+export const SET_ALIAS = booleanOr(core.getInput('set_alias'), DEFAULT_SET_ALIAS);
+export const MIGRATIONS_DIR = path.join(GITHUB_WORKSPACE, getInputOr('migrations_dir', DEFAULT_MIGRATIONS_DIR));
 
 export const CONTENTFUL_ALIAS = "master";
 export const DELAY = 3000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,8 +18,9 @@ const booleanOr = (str: string, fallback: boolean): boolean => {
 };
 
 const getInputOr = (coreInput: string, fallback: string): string => {
-  if ( coreInput ) {
-    return core.getInput(coreInput);
+  const input = core.getInput(coreInput);
+  if (input) {
+    return input;
   }
   return fallback;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,6 +32,8 @@ export const DEFAULT_VERSION_FIELD = "version";
 export const DEFAULT_DELETE_FEATURE = false;
 export const DEFAULT_SET_ALIAS = false;
 
+export const SPACE_ID = core.getInput('space_id', { required: true });
+export const MANAGEMENT_API_KEY = core.getInput('management_api_key', { required: true });
 export const VERSION_CONTENT_TYPE = getInputOr('version_content_type', DEFAULT_VERSION_CONTENT_TYPE);
 export const FEATURE_PATTERN = getInputOr('feature_pattern', DEFAULT_FEATURE_PATTERN);
 export const MASTER_PATTERN = getInputOr('master_pattern', DEFAULT_MASTER_PATTERN);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,16 @@
 import * as core from "@actions/core";
 import { createClient } from "contentful-management";
 import { runAction } from "./action";
-import { MANAGEMENT_API_KEY, SPACE_ID } from "./constants";
 import { Logger } from "./utils";
 
 (async () => {
-  const client = createClient({
-    accessToken: MANAGEMENT_API_KEY,
-  });
-  const space = await client.getSpace(SPACE_ID);
   try {
+    const accessToken = core.getInput('management_api_key', { required: true });
+    const spaceId = core.getInput('space_id', { required: true });
+    const client = createClient({
+      accessToken: accessToken,
+    });
+    const space = await client.getSpace(spaceId);
     await runAction(space);
   } catch (error) {
     Logger.error(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,17 @@ import * as core from "@actions/core";
 import { createClient } from "contentful-management";
 import { runAction } from "./action";
 import { Logger } from "./utils";
+import {
+  MANAGEMENT_API_KEY,
+  SPACE_ID,
+} from './constants';
 
 (async () => {
   try {
-    const accessToken = core.getInput('management_api_key', { required: true });
-    const spaceId = core.getInput('space_id', { required: true });
     const client = createClient({
-      accessToken: accessToken,
+      accessToken: MANAGEMENT_API_KEY,
     });
-    const space = await client.getSpace(spaceId);
+    const space = await client.getSpace(SPACE_ID);
     await runAction(space);
   } catch (error) {
     Logger.error(error);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export interface EnvironmentNames {
   head: string | null;
 }
 
-type EnvironmentType = "master" | "feature";
+export type EnvironmentType = "master" | "feature";
 
 export interface EnvironmentProps {
   environmentType: EnvironmentType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,8 @@
-import * as github from "@actions/github";
-import chalk from "chalk";
-import { Space } from "contentful-management/dist/typings/entities/space";
-import {
-  CONTENTFUL_ALIAS,
-  DELAY,
-  FEATURE_PATTERN,
-  LOG_LEVEL,
-  MASTER_PATTERN,
-} from "./constants";
-import {
-  BranchNames,
-  EnvironmentProps,
-  EventNames,
-  NameFromPatternArgs,
-} from "./types";
+import * as github from '@actions/github';
+import chalk from 'chalk';
+import { Space } from 'contentful-management/dist/typings/entities/space';
+import { CONTENTFUL_ALIAS, DELAY, FEATURE_PATTERN, LOG_LEVEL, MASTER_PATTERN } from './constants';
+import { BranchNames, EnvironmentProps, EnvironmentType, EventNames, NameFromPatternArgs } from './types';
 
 // Force colors on github
 chalk.level = 3;
@@ -23,16 +12,16 @@ export const Logger = {
     console.log(chalk.white(message));
   },
   success(message) {
-    console.log("✅", chalk.green(message));
+    console.log('✅', chalk.green(message));
   },
   error(message) {
-    console.log("💩", chalk.red(message));
+    console.log('💩', chalk.red(message));
   },
   warn(message) {
-    console.log("⚠️", chalk.yellow(message));
+    console.log('⚠️', chalk.yellow(message));
   },
   verbose(message) {
-    if (LOG_LEVEL === "verbose") {
+    if (LOG_LEVEL === 'verbose') {
       console.log(chalk.white(message));
     }
   },
@@ -42,8 +31,7 @@ export const Logger = {
  * Promise based delay
  * @param time
  */
-export const delay = (time = DELAY): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, time));
+export const delay = (time = DELAY): Promise<void> => new Promise((resolve) => setTimeout(resolve, time));
 
 /**
  * Convert fileNames to versions
@@ -51,8 +39,7 @@ export const delay = (time = DELAY): Promise<void> =>
  * filenameToVersion("1.js") // "1"
  * filenameToVersion("1.0.1.js") // "1.0.1"
  */
-export const filenameToVersion = (file: string): string =>
-  file.replace(/\.js$/, "").replace(/_/g, ".");
+export const filenameToVersion = (file: string): string => file.replace(/\.js$/, '').replace(/_/g, '.');
 
 /**
  * Convert versions to filenames
@@ -60,41 +47,34 @@ export const filenameToVersion = (file: string): string =>
  * versionToFilename("1") // "1.js"
  * versionToFilename("1.0.1") // "1.0.1.js"
  */
-export const versionToFilename = (version: string): string =>
-  `${version.replace(/\\./g, "_")}.js`;
+export const versionToFilename = (version: string): string => `${version.replace(/\\./g, '_')}.js`;
 
 /**
  * Convert a branchName to a valid environmentName
  * @param branchName
  */
-export const branchNameToEnvironmentName = (branchName: string): string =>
-  branchName.replace(/[\/_.]/g, "-");
+export const branchNameToEnvironmentName = (branchName: string): string => branchName.replace(/[\/_.]/g, '-');
 
 export enum Matcher {
-  YY = "YY",
-  YYYY = "YYYY",
-  MM = "MM",
-  DD = "DD",
-  hh = "hh",
-  mm = "mm",
-  ss = "ss",
-  branch = "branch",
+  YY = 'YY',
+  YYYY = 'YYYY',
+  MM = 'MM',
+  DD = 'DD',
+  hh = 'hh',
+  mm = 'mm',
+  ss = 'ss',
+  branch = 'branch',
 }
 
 export const matchers = {
-  [Matcher.ss]: (date: Date): string =>
-    `${date.getUTCSeconds()}`.padStart(2, "0"),
-  [Matcher.hh]: (date: Date): string =>
-    `${date.getUTCHours()}`.padStart(2, "0"),
-  [Matcher.mm]: (date: Date): string =>
-    `${date.getUTCMinutes()}`.padStart(2, "0"),
+  [Matcher.ss]: (date: Date): string => `${date.getUTCSeconds()}`.padStart(2, '0'),
+  [Matcher.hh]: (date: Date): string => `${date.getUTCHours()}`.padStart(2, '0'),
+  [Matcher.mm]: (date: Date): string => `${date.getUTCMinutes()}`.padStart(2, '0'),
   [Matcher.YYYY]: (date: Date): string => `${date.getUTCFullYear()}`,
   [Matcher.YY]: (date: Date): string => `${date.getUTCFullYear()}`.substr(2, 2),
-  [Matcher.MM]: (date: Date): string =>
-    `${date.getUTCMonth() + 1}`.padStart(2, "0"),
-  [Matcher.DD]: (date: Date): string => `${date.getDate()}`.padStart(2, "0"),
-  [Matcher.branch]: (branchName: string): string =>
-    branchNameToEnvironmentName(branchName),
+  [Matcher.MM]: (date: Date): string => `${date.getUTCMonth() + 1}`.padStart(2, '0'),
+  [Matcher.DD]: (date: Date): string => `${date.getDate()}`.padStart(2, '0'),
+  [Matcher.branch]: (branchName: string): string => branchNameToEnvironmentName(branchName),
 };
 
 /**
@@ -102,30 +82,24 @@ export const matchers = {
  * @param pattern
  * @param branchName
  */
-export const getNameFromPattern = (
-  pattern: string,
-  { branchName }: NameFromPatternArgs = {}
-): string => {
+export const getNameFromPattern = (pattern: string, { branchName }: NameFromPatternArgs = {}): string => {
   const date = new Date();
-  return pattern.replace(
-    /\[(YYYY|YY|MM|DD|hh|mm|ss|branch)]/g,
-    (substring, match: Matcher) => {
-      switch (match) {
-        case Matcher.branch:
-          return matchers[Matcher.branch](branchName);
-        case Matcher.YYYY:
-        case Matcher.YY:
-        case Matcher.MM:
-        case Matcher.DD:
-        case Matcher.hh:
-        case Matcher.mm:
-        case Matcher.ss:
-          return matchers[match](date);
-        default:
-          return substring;
-      }
+  return pattern.replace(/\[(YYYY|YY|MM|DD|hh|mm|ss|branch)]/g, (substring, match: Matcher) => {
+    switch (match) {
+      case Matcher.branch:
+        return matchers[Matcher.branch](branchName);
+      case Matcher.YYYY:
+      case Matcher.YY:
+      case Matcher.MM:
+      case Matcher.DD:
+      case Matcher.hh:
+      case Matcher.mm:
+      case Matcher.ss:
+        return matchers[match](date);
+      default:
+        return substring;
     }
-  );
+  });
 };
 
 /**
@@ -147,10 +121,10 @@ export const getBranchNames = (): BranchNames => {
         defaultBranch,
       };
     // If not pullRequest we need work on the baseRef therefore head is null
-    default:      
+    default:
       return {
         headRef: null,
-        baseRef: payload.ref.replace(/^refs\/heads\//, ""),
+        baseRef: payload.ref.replace(/^refs\/heads\//, ''),
         defaultBranch,
       };
   }
@@ -162,30 +136,24 @@ export const getBranchNames = (): BranchNames => {
  * @param space
  * @param branchNames
  */
-export const getEnvironment = async (
-  space: Space,
-  branchNames: BranchNames
-): Promise<EnvironmentProps> => {
+export const getEnvironment = async (space: Space, branchNames: BranchNames): Promise<EnvironmentProps> => {
   const environmentNames = {
     base: branchNameToEnvironmentName(branchNames.baseRef),
-    head: branchNames.headRef
-      ? branchNameToEnvironmentName(branchNames.headRef)
-      : null,
+    head: branchNames.headRef ? branchNameToEnvironmentName(branchNames.headRef) : null,
   };
 
   // If the Pull Request is merged and the base is the repository default_name (master|main, ...)
   // Then create an environment name for the given master_pattern
   // Else create an environment name for the given feature_pattern
-  
-  Logger.verbose(
-    `MASTER_PATTERN: ${MASTER_PATTERN} | FEATURE_PATTERN: ${FEATURE_PATTERN}`
-  );
 
-  const environmentType =
-    branchNames.baseRef === branchNames.defaultBranch &&
-    github.context.payload.pull_request?.merged
-      ? CONTENTFUL_ALIAS
-      : "feature";
+  Logger.verbose(`MASTER_PATTERN: ${MASTER_PATTERN} | FEATURE_PATTERN: ${FEATURE_PATTERN}`);
+
+  let environmentType: EnvironmentType =
+    branchNames.baseRef === branchNames.defaultBranch ? CONTENTFUL_ALIAS : 'feature';
+
+  if (github.context.payload?.pull_request?.merged) {
+    environmentType = 'feature';
+  }
 
   Logger.verbose(`Environment type: ${environmentType}`);
 
@@ -211,9 +179,7 @@ export const getEnvironment = async (
     };
   }
   // Else we need to check for an existing environment and flush it
-  Logger.log(
-    `Checking for existing versions of environment: "${environmentId}"`
-  );
+  Logger.log(`Checking for existing versions of environment: "${environmentId}"`);
 
   try {
     const environment = await space.getEnvironment(environmentId);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,6 +135,8 @@ export const getBranchNames = (): BranchNames => {
   const { eventName, payload, ref } = github.context;
   const { default_branch: defaultBranch } = payload.repository;
 
+  Logger.verbose(`Getting branch names for ${eventName}`);
+
   // Check the eventName
   switch (eventName) {
     // If pullRequest we need to get the head and base
@@ -146,9 +148,10 @@ export const getBranchNames = (): BranchNames => {
       };
     // If not pullRequest we need work on the baseRef therefore head is null
     default:
+      Logger.verbose(`Return branch names for ${eventName} with baseRef ${payload.ref}`);
       return {
         headRef: null,
-        baseRef: ref.replace(/^refs\/heads\//, ""),
+        baseRef: payload.ref.replace(/^refs\/heads\//, ""),
         defaultBranch,
       };
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -135,7 +135,7 @@ export const getBranchNames = (): BranchNames => {
   const { eventName, payload, ref } = github.context;
   const { default_branch: defaultBranch } = payload.repository;
 
-  Logger.verbose(`Getting branch names for ${eventName}`);
+  Logger.verbose(`Getting branch names for "${eventName}"`);
 
   // Check the eventName
   switch (eventName) {
@@ -147,8 +147,7 @@ export const getBranchNames = (): BranchNames => {
         defaultBranch,
       };
     // If not pullRequest we need work on the baseRef therefore head is null
-    default:
-      Logger.verbose(`Return branch names for ${eventName} with baseRef ${payload.ref}`);
+    default:      
       return {
         headRef: null,
         baseRef: payload.ref.replace(/^refs\/heads\//, ""),
@@ -173,17 +172,22 @@ export const getEnvironment = async (
       ? branchNameToEnvironmentName(branchNames.headRef)
       : null,
   };
+
   // If the Pull Request is merged and the base is the repository default_name (master|main, ...)
   // Then create an environment name for the given master_pattern
   // Else create an environment name for the given feature_pattern
+  
   Logger.verbose(
     `MASTER_PATTERN: ${MASTER_PATTERN} | FEATURE_PATTERN: ${FEATURE_PATTERN}`
   );
+
   const environmentType =
     branchNames.baseRef === branchNames.defaultBranch &&
     github.context.payload.pull_request?.merged
       ? CONTENTFUL_ALIAS
       : "feature";
+
+  Logger.verbose(`Environment type: ${environmentType}`);
 
   const environmentId =
     environmentType === CONTENTFUL_ALIAS
@@ -191,6 +195,7 @@ export const getEnvironment = async (
       : getNameFromPattern(FEATURE_PATTERN, {
           branchName: branchNames.headRef,
         });
+
   Logger.verbose(`environmentId: "${environmentId}"`);
 
   // If environment matches ${CONTENTFUL_ALIAS} ("master")

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,7 +132,7 @@ export const getNameFromPattern = (
  * Get the branchNames based on the eventName
  */
 export const getBranchNames = (): BranchNames => {
-  const { eventName, payload } = github.context;
+  const { eventName, payload, ref } = github.context;
   const { default_branch: defaultBranch } = payload.repository;
 
   // Check the eventName
@@ -148,7 +148,7 @@ export const getBranchNames = (): BranchNames => {
     default:
       return {
         headRef: null,
-        baseRef: payload.ref.replace(/^refs\/heads\//, ""),
+        baseRef: ref.replace(/^refs\/heads\//, ""),
         defaultBranch,
       };
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -151,7 +151,9 @@ export const getEnvironment = async (space: Space, branchNames: BranchNames): Pr
   let environmentType: EnvironmentType =
     branchNames.baseRef === branchNames.defaultBranch ? CONTENTFUL_ALIAS : 'feature';
 
-  if (github.context.payload?.pull_request?.merged) {
+  // If pull request have been merged or there exists a headRef (comes only from a PR) then set
+  // enironment type to feature
+  if (github.context.payload?.pull_request?.merged || branchNames.headRef ) {
     environmentType = 'feature';
   }
 
@@ -164,7 +166,7 @@ export const getEnvironment = async (space: Space, branchNames: BranchNames): Pr
           branchName: branchNames.headRef,
         });
 
-  Logger.verbose(`environmentId: "${environmentId}"`);
+  Logger.verbose(`Environment id: "${environmentId}"`);
 
   // If environment matches ${CONTENTFUL_ALIAS} ("master")
   // Then return it without further actions


### PR DESCRIPTION
I had a couple of problems when I started using this package. 

1. The documentation and source code differ on what the env actually is. In this PR I've changed the input to be used with the normal approach `core.getInput`. This way it can fail if it doesn't receive the required inputs. Only the verbose logging remains as an env variable.

2. Pushing to a main|master branch didn't create a master environment in contentful. I've changed the if statement for either letting it become a master or feature environment. This could probably be done in a better way and definitely needs to be tested more but at least in my use case, it works as intended. 