### PR TITLE
Add contentful_alias as optional param

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         delete_feature: false
         set_alias: true
+        contentful_alias: "staging"
         master_pattern: "prod-[DD].[MM].[YYYY]-[hh][mm][ss]"
         feature_pattern: "sandbox-[branch]"
         version_field: version

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ the sandbox environment.
 `set_alias`: Will set the alias to the new master environment once the feature has been merged. You might want to
 manually set the alias from the GUI. 
 
+`contentful_alias`: Will use as the alias to update. Defaults to master
+
 ## Versioning
 
 Please read the usage info above. The content-type and the field-id are configurable. 
@@ -95,6 +97,7 @@ Name | Type | Required | Default  | Description
 **management_api_key**   | `string`  | Yes | `undefined` | The management-api key for contentful
 delete_feature           | `boolean` | No  | `false` | Deletes sandbox environment if the head branch is merged
 set_alias                | `boolean` | No  | `false` | Aliases master the new master environment
+contentful_alias         | `string`  | No  | `master` | Alias to update
 master_pattern           | `string`  | No  | `master-[YYYY]-[MM]-[DD]-[hh][mm]` | The pattern that should be used for the new master environment on contentful
 feature_pattern          | `string`  | No  | `GH-[branch]` | The pattern that should be used for the new feature environments on contentful
 version_content_type     | `string`  | No  | `versionTracking` | The content-type that tracks the version
@@ -113,6 +116,7 @@ Please look at the [demo file](.github/workflows/main.yml).
   with:
     # delete_feature: true
     # set_alias: true
+    # contentful_alias: "staging"
     # master_pattern: "main-[YY]-[MM]-[DD]-[hh]-[mm]"
     # feature_pattern: "sandbox-[branch]"
     # version_field: versionCounter

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: "The head branch will be deleted after it was merged"
   set_alias:
     description: "The master will be aliased to the new master"
+  contentful_alias:
+    description: "Specify a different alias to update (default: master)"
   master_pattern:
     description: "The pattern that should be used for the new master"
   feature_pattern:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,6 +12,7 @@ export const {
   INPUT_MASTER_PATTERN,
   INPUT_VERSION_CONTENT_TYPE,
   INPUT_VERSION_FIELD,
+  INPUT_CONTENTFUL_ALIAS,
 } = process.env;
 
 const booleanOr = (str: string, fallback: boolean): boolean => {
@@ -32,6 +33,7 @@ export const DEFAULT_VERSION_CONTENT_TYPE = "versionTracking";
 export const DEFAULT_VERSION_FIELD = "version";
 export const DEFAULT_DELETE_FEATURE = false;
 export const DEFAULT_SET_ALIAS = false;
+export const DEFAULT_CONTENTFUL_ALIAS = "master";
 
 export const VERSION_CONTENT_TYPE =
   INPUT_VERSION_CONTENT_TYPE || DEFAULT_VERSION_CONTENT_TYPE;
@@ -48,6 +50,6 @@ export const MIGRATIONS_DIR = path.join(
   INPUT_MIGRATIONS_DIR || DEFAULT_MIGRATIONS_DIR
 );
 
-export const CONTENTFUL_ALIAS = "master";
+export const CONTENTFUL_ALIAS = INPUT_CONTENTFUL_ALIAS || DEFAULT_CONTENTFUL_ALIAS;
 export const DELAY = 3000;
 export const MAX_NUMBER_OF_TRIES = 10;


### PR DESCRIPTION
Theoretically, this lets us change which alias we're updating when we clone. We want to be able to differentiate between a clone and alias of staging and a clone and alias of master within our CI/CD